### PR TITLE
Treat initialisms as ordinary words

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ Translations of the guide are available in the following languages:
   ```
 
 * <a name="camel-case"></a>
-  Use `CamelCase` for modules (keep acronyms like HTTP, RFC, XML uppercase).
+  Use `CamelCase` for modules. Treat initialisms like ordinary words.
   <sup>[[link](#camel-case)]</sup>
 
   ```elixir
@@ -621,7 +621,7 @@ Translations of the guide are available in the following languages:
     ...
   end
 
-  defmodule SomeXml do
+  defmodule SomeXML do
     ...
   end
 
@@ -630,7 +630,7 @@ Translations of the guide are available in the following languages:
     ...
   end
 
-  defmodule SomeXML do
+  defmodule SomeXml do
     ...
   end
   ```


### PR DESCRIPTION
Why
---

Rendering initialisms/acronyms in uppercase can lead to hard-to-read and sometimes confusing module names. Take **HTTPSandbox** for example. If we follow the parsing rules, then it is clearly referring to an “HTTP sandbox” module, however this requires more cognitive labor than parsing `HttpSandbox`… especially since HTTPS has its own meaning. Worse still are those that involve multiple initialisms back to back. Consider **NSASQLQuery**; there is no parsing rule that can handle this. The user has to know that NSA and SQL are separate initialisms to correctly identify this as an “NSA SQL query” module.

How
---

Update `#camel-case` rule