### PR TITLE
Remove self-referencing alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,20 +885,6 @@ Translations of the guide are available in the following languages:
   end
   ```
 
-* <a name="alias-self-referencing-modules"></a>
-  If you want a prettier name for a module self-reference, set up an alias.
-  <sup>[[link](#alias-self-referencing-modules)]</sup>
-
-  ```elixir
-  defmodule SomeProject.SomeModule do
-    alias __MODULE__, as: SomeModule
-
-    defstruct [:name]
-
-    def name(%SomeModule{name: name}), do: name
-  end
-  ```
-
 * <a name="repetitive-module-names"></a>
   Avoid repeating fragments in module names and namespaces.
   This improves overall readability and


### PR DESCRIPTION
Why
---

This practice is needless and could lead to confusion as a module’s name and its meaning grow apart from the alias. If they are kept in sync, then the entire benefit of the `__MODULE__` pseudo variable is lost.

How
---

Remove `#alias-self-referencing-modules` tip