### PR TITLE
Clarify that access is not bare

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,28 @@ generally preferred practice.
   |> String.strip()
   |> String.downcase()
   |> String.codepoints()
+
+  # not preferred
+  keyed_structure[key]
+  |> Float.round()
+  |> Float.to_string()
+
+  # preferred
+  keyed_structure
+  |> Access.get(key)
+  |> Float.round()
+  |> Float.to_string()
+
+  # not preferred
+  map.date
+  |> Date.add(7)
+  |> Date.quarter_of_year()
+
+  # preferred
+  map
+  |> Map.fetch!(date)
+  |> Date.add(7)
+  |> Date.quarter_of_year()
   ```
 
 * <a name="parentheses"></a>


### PR DESCRIPTION
Why
---

The examples for the `#bare-variables` rule only demonstrated standard function calls

How
---

Add bracket- and dot-based access examples to `#bare-variables`