### PR TITLE
Remove do with single-line if/unless

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,6 @@ generally preferred practice.
   end
   ```
 
-* <a name="do-with-single-line-if-unless"></a>
-  Use `do:` for single line `if/unless` statements.
-  <sup>[[link](#do-with-single-line-if-unless)]</sup>
-
-  ```elixir
-  # preferred
-  if some_condition, do: # some_stuff
-  ```
-
 * <a name="unless-with-else"></a>
   Never use `unless` with `else`.
   Rewrite these with the positive case first.


### PR DESCRIPTION
Why
---

This is situation-specific. For example, this module is eminently more readable without applying the `#do-with-single-line-if-unless` rule:

```elixir
defmodule WebApp.Router do
  use Plug.Router

  if Mix.env() === :dev do
    forward "/dashboard", to: WebApp.DashboardPlug
  end

  get "/hello" do
    send_resp(conn, 200, "world")
  end

  match _ do
    send_resp(conn, 404, "oops")
  end
end
```

Unquestioning application of the rule can also cause macro calls (e.g., `with`, `for`) to become syntactically distorted.

How
---

Remove `#do-with-single-line-if-unless` rule